### PR TITLE
server specific early upgrade network-store-client 1.37.0 -> 1.38.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,9 @@
         <gridsuite-dependencies.version>47.0.0</gridsuite-dependencies.version>
         <sonar.organization>gridsuite</sonar.organization>
         <sonar.projectKey>org.gridsuite:balances-adjustment-server</sonar.projectKey>
+
+        <!-- TODO network-store.version remove when included in powsybl-ws-dependencies -->
+        <network-store-client.version>1.38.0</network-store-client.version>
     </properties>
 
     <build>
@@ -79,6 +82,24 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- FIXME: to be removed at next powsybl-ws-dependencies upgrade  -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-network-store-client</artifactId>
+                <version>${network-store-client.version}</version>
+            </dependency>
+            <!-- FIXME: to be removed at next powsybl-ws-dependencies upgrade  -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-network-store-iidm-impl</artifactId>
+                <version>${network-store-client.version}</version>
+            </dependency>
+            <!-- FIXME: to be removed at next powsybl-ws-dependencies upgrade  -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-network-store-model</artifactId>
+                <version>${network-store-client.version}</version>
+            </dependency>
 
             <!-- imports -->
             <dependency>


### PR DESCRIPTION
To be able to use the new useCalculatedBusFictitiousP0Q0 param to improve openloadflow execution time

## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->



